### PR TITLE
feat: gov mod for ibc and permisionless optional relay

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -129,7 +129,7 @@ import (
 
 const (
 	Name       = "centauri"
-	dirName    = "banksy"
+	dirName    = "centauri"
 	ForkHeight = 244008
 )
 

--- a/app/app.go
+++ b/app/app.go
@@ -129,7 +129,7 @@ import (
 
 const (
 	Name       = "centauri"
-	dirName    = "bansky"
+	dirName    = "banksy"
 	ForkHeight = 244008
 )
 

--- a/app/app.go
+++ b/app/app.go
@@ -129,7 +129,7 @@ import (
 
 const (
 	Name       = "centauri"
-	dirName    = "centauri"
+	dirName    = "bansky"
 	ForkHeight = 244008
 )
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -107,7 +107,6 @@ import (
 
 const (
 	AccountAddressPrefix = "composable"
-	authorityAddress     = "centauri10556m38z4x6pqalr9rl5ytf3cff8q46nk85k9m" // convert from: centauri10556m38z4x6pqalr9rl5ytf3cff8q46nk85k9m
 )
 
 type AppKeepers struct {
@@ -246,7 +245,9 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appCodec, appKeepers.keys[ibchost.StoreKey], appKeepers.GetSubspace(ibchost.ModuleName), appKeepers.StakingKeeper, appKeepers.UpgradeKeeper, appKeepers.ScopedIBCKeeper,
 	)
 
-	appKeepers.Wasm08Keeper = wasm08Keeper.NewKeeper(appCodec, appKeepers.keys[wasmtypes.StoreKey], authorityAddress, homePath, &appKeepers.IBCKeeper.ClientKeeper)
+	govModuleAuthority := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
+	appKeepers.Wasm08Keeper = wasm08Keeper.NewKeeper(appCodec, appKeepers.keys[wasmtypes.StoreKey], govModuleAuthority, homePath, &appKeepers.IBCKeeper.ClientKeeper)
 
 	// ICA Host keeper
 	appKeepers.ICAHostKeeper = icahostkeeper.NewKeeper(
@@ -284,13 +285,13 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		&appKeepers.RatelimitKeeper,
 		&appKeepers.TransferKeeper,
 		appKeepers.BankKeeper,
-		authorityAddress,
+		govModuleAuthority,
 	)
 
 	appKeepers.TxBoundaryKeepper = txBoundaryKeeper.NewKeeper(
 		appCodec,
 		appKeepers.keys[txBoundaryTypes.StoreKey],
-		authorityAddress,
+		govModuleAuthority,
 	)
 
 	appKeepers.TransferKeeper = ibctransferkeeper.NewKeeper(
@@ -408,7 +409,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 
 	govKeeper := *govkeeper.NewKeeper(
 		appCodec, appKeepers.keys[govtypes.StoreKey], appKeepers.AccountKeeper, appKeepers.BankKeeper,
-		appKeepers.StakingKeeper, bApp.MsgServiceRouter(), govtypes.DefaultConfig(), authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		appKeepers.StakingKeeper, bApp.MsgServiceRouter(), govtypes.DefaultConfig(), govModuleAuthority,
 	)
 
 	govKeeper.SetLegacyRouter(govRouter)

--- a/x/transfermiddleware/keeper/keeper.go
+++ b/x/transfermiddleware/keeper/keeper.go
@@ -164,7 +164,16 @@ func (keeper Keeper) HasAllowRlyAddress(ctx sdk.Context, rlyAddress string) bool
 	store := ctx.KVStore(keeper.storeKey)
 	key := types.GetKeyByRlyAddress(rlyAddress)
 
-	return store.Has(key)
+	if store.Has(key) {
+		return true
+	}
+
+	prefixStore := prefix.NewStore(store, types.KeyRlyAddress)
+	iter := prefixStore.Iterator(nil, nil)
+	defer iter.Close()
+
+	// there are not records => so it is permissionless
+	return !iter.Valid()
 }
 
 func (keeper Keeper) IterateAllowRlyAddress(ctx sdk.Context, cb func(rlyAddress string) (stop bool)) {

--- a/x/transfermiddleware/types/parachain_token_info.pb.go
+++ b/x/transfermiddleware/types/parachain_token_info.pb.go
@@ -28,7 +28,7 @@ var _ = time.Kitchen
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // ParachainIBCTokenInfo represents information about transferable IBC tokens
-// from Parachain.
+// from Parachain(Substrate based network).
 type ParachainIBCTokenInfo struct {
 	// ibc_denom is the denomination of the ibced token transferred from the
 	// dotsama chain.


### PR DESCRIPTION
1. made gov to own what previosly vlad key did, first it ensures that security level of this chain same as piccasso, to prevent mint anything by anybody by wasm light client. second it allows to run devnet (previosly only vlad could)
2.  making other than vlad key to relay. so if there is relay filter - sure it is used, but when removed all filters - anybody can relay. on mainnet and devnet
3. also used centauri folder for storage like any other chains do more or less.