### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+    labels:
+      - automerge
+      - dependencies


### PR DESCRIPTION
Dependabot will keep github actions and go modules up to date automatically. 

When we don't want a change, we just close the PR it makes. 

We should merge this because numerous actions are out of date. 