### PR TITLE
fix interchaintest image location

### DIFF
--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -33,7 +33,7 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ghcr.io/notional-labs/centauri-ictest:latest
+            ghcr.io/ComposableFi/composable-cosmos/centauri-ictest:latest
   test-start-cosmos-chain:
     runs-on: ubuntu-latest
     needs: build-and-push-image


### PR DESCRIPTION
closes: #279 


corrects the url for the ict image