### PR TITLE
Update tests github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,21 +1,15 @@
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      
-name: Tests
-
+on: [push, pull_request]
+name: Test
 jobs:
   test:
-    runs-on: ubuntu-latest
-    name: test
+    strategy:
+      matrix:
+        go-version: [1.21.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Test
-        run: go test ./...
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+    - run: go test ./...

--- a/x/transfermiddleware/ibc_ante_test.go
+++ b/x/transfermiddleware/ibc_ante_test.go
@@ -15,7 +15,12 @@ import (
 	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
 )
 
-var govAuthorityAddress = "centauri10556m38z4x6pqalr9rl5ytf3cff8q46nk85k9m" // convert from: centauri10556m38z4x6pqalr9rl5ytf3cff8q46nk85k9m
+// NOTE: This is the address of the gov authority on the chain that is being tested.
+// This means that we need to check bech32 .... everywhere.
+var govAuthorityAddress = "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn"
+
+// ORIGINAL NOTES:
+// convert from: centauri10556m38z4x6pqalr9rl5ytf3cff8q46nk85k9m
 
 type TransferTestSuite struct {
 	suite.Suite


### PR DESCRIPTION
This PR updates the tests github action.  They were not running on every branch and that allowed a test failure to get to the master branch.

We need to update ict and others to 50. 

This also fixes a test failure, where the test is looking for a cosmos1 governance address.  However, this is a temporary fix and we should look to better configure the bech32prefix for the test chains that interchaintest runs, per #300. 