### PR TITLE
compatiblity check

### DIFF
--- a/.github/workflows/compatible.yml
+++ b/.github/workflows/compatible.yml
@@ -9,7 +9,8 @@ on:
 name: compatibility check
 # This CI job will do what many validators do: get a recent polkachu snapshot and run.  
 # For now, this ci job may need to be manually updated to keep the snapshot up to date. 
-# In a success case, this job will run the chain for five minutes, computing each block and arriving at the same block hash / app hash. 
+# In a success case, this job will run the chain for ten minutes, computing each block and arriving at the same block hash / app hash. 
+# This way, we can test various scenarios and know that changes are highly unlikely to be breaking. 
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,12 +28,12 @@ jobs:
           go-version: 1.19
       - run: |
           go install ./...
-          centaurid init
+          centaurid init github
           wget https://snapshots.polkachu.com/snapshots/composable/composable_3035461.tar.lz4
           wget https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json
           mv genesis.json  ~/.banksy/config/genesis.json
           mv composable_3035461.tar.lz4 ~/.banksy/composable_3035461.tar.lz4
           cd ~/.banksy
           lz4 -d composable_3035461.tar.lz4 | tar -xvf -
-          timeout 5m centaurid start --p2p.seeds "ebc272824924ea1a27ea3183dd0b9ba713494f83@composable-mainnet-seed.autostake.com:26976,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:22256,d2362ebcdd562500ac8c4cfa2214a89ad811033c@seeds.whispernode.com:22256"
+          timeout 10m centaurid start --p2p.seeds "ebc272824924ea1a27ea3183dd0b9ba713494f83@composable-mainnet-seed.autostake.com:26976,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:22256,d2362ebcdd562500ac8c4cfa2214a89ad811033c@seeds.whispernode.com:22256"
         

--- a/.github/workflows/compatible.yml
+++ b/.github/workflows/compatible.yml
@@ -1,8 +1,7 @@
 on:
   push:
-    paths:
-      - '**.go'      
-      - 'go.sum'
+    branches:
+      - release/v6.3.x
   pull_request:
     branches:
       - release/v6.3.x

--- a/.github/workflows/compatible.yml
+++ b/.github/workflows/compatible.yml
@@ -13,7 +13,7 @@ name: compatibility check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/compatible.yml
+++ b/.github/workflows/compatible.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    paths:
+      - '**.go'      
+      - 'go.sum'
+  pull_request:
+    branches:
+      - release/v6.3.x
+name: compatibility check
+# This CI job will do what many validators do: get a recent polkachu snapshot and run.  
+# For now, this ci job may need to be manually updated to keep the snapshot up to date. 
+# In a success case, this job will run the chain for five minutes, computing each block and arriving at the same block hash / app hash. 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - run: |
+          go install ./...
+          centaurid init
+          wget https://snapshots.polkachu.com/snapshots/composable/composable_3035461.tar.lz4
+          wget https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json
+          mv genesis.json  ~/.banksy/config/genesis.json
+          mv composable_3035461.tar.lz4 ~/.banksy/composable_3035461.tar.lz4
+          cd ~/.banksy
+          lz4 -d composable_3035461.tar.lz4 | tar -xvf -
+          timeout 5m centaurid start --p2p.seeds "ebc272824924ea1a27ea3183dd0b9ba713494f83@composable-mainnet-seed.autostake.com:26976,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:22256,d2362ebcdd562500ac8c4cfa2214a89ad811033c@seeds.whispernode.com:22256"
+        

--- a/.github/workflows/compatible.yml
+++ b/.github/workflows/compatible.yml
@@ -29,11 +29,11 @@ jobs:
       - run: |
           go install ./...
           centaurid init github
-          wget https://snapshots.polkachu.com/snapshots/composable/composable_3035461.tar.lz4
+          wget -q https://snapshots.polkachu.com/snapshots/composable/composable_3035461.tar.lz4
           wget https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json
           mv genesis.json  ~/.banksy/config/genesis.json
           mv composable_3035461.tar.lz4 ~/.banksy/composable_3035461.tar.lz4
           cd ~/.banksy
           lz4 -d composable_3035461.tar.lz4 | tar -xvf -
-          timeout 10m centaurid start --p2p.seeds "ebc272824924ea1a27ea3183dd0b9ba713494f83@composable-mainnet-seed.autostake.com:26976,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:22256,d2362ebcdd562500ac8c4cfa2214a89ad811033c@seeds.whispernode.com:22256"
+          timeout 10m centaurid start --p2p.seeds "ebc272824924ea1a27ea3183dd0b9ba713494f83@composable-mainnet-seed.autostake.com:26976,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:22256,d2362ebcdd562500ac8c4cfa2214a89ad811033c@seeds.whispernode.com:22256" || ( [[ $? -eq 124 ]] && echo "HAPPY: Timeout reached without apphash issues" )
         

--- a/cmd/centaurid/cmd/root.go
+++ b/cmd/centaurid/cmd/root.go
@@ -93,8 +93,8 @@ func initTendermintConfig() *tmcfg.Config {
 	cfg := tmcfg.DefaultConfig()
 
 	// these values put a higher strain on node memory
-	// cfg.P2P.MaxNumInboundPeers = 100
-	// cfg.P2P.MaxNumOutboundPeers = 40
+	cfg.P2P.MaxNumInboundPeers = 400
+	cfg.P2P.MaxNumOutboundPeers = 50
 
 	return cfg
 }

--- a/cmd/centaurid/main.go
+++ b/cmd/centaurid/main.go
@@ -15,7 +15,7 @@ func main() {
 	cmdcfg.RegisterDenoms()
 
 	rootCmd, _ := cmd.NewRootCmd()
-	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {
+	if err := svrcmd.Execute(rootCmd, "CENTAURID", app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
In order to **safely** update the v6.3.x series, we're introducing a compatibility check that mirrors validator behavior:

* download a polkachu snapshot
* start the chain with seeds from the chain registry
* the chain will run for 10 minutes.  If the timeout command returns exit code 124, then the entire last command will return zero (success)

----

This PR makes a few other changes:

* increases the default number of inbound and outbound peers (in an 8 in 1 out ratio) to prevent chokes as seen on the cosmos hub
* adds a fixed CENTAURID for environment variables instead of ""