### PR TITLE
ensure codeql runs on all release branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - release/**
   push:
     branches:
       - master
+      - release/**
 
 jobs:
   analyze:


### PR DESCRIPTION
This PR ensures that codeql will run on release branches. 