### PR TITLE
use devskim on all release branches

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -7,9 +7,13 @@ name: DevSkim
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches:
+      - master
+      - release/**
   pull_request:
-    branches: [ "master" ]
+    branches: 
+      - master
+      - release/**
   schedule:
     - cron: '15 6 * * 0'
 


### PR DESCRIPTION
This PR ensures that devskim, a CI bug-checking tool, runs on all release branches. 