### PR TITLE
docker fixes + reward distribution transfer function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.19"
+ARG GO_VERSION="1.20"
 ARG RUNNER_IMAGE="gcr.io/distroless/static-debian11"
 
 # --------------------------------------------------------

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.19"
+ARG GO_VERSION="1.20"
 ARG RUNNER_IMAGE="alpine:3.16"
 
 # --------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ lint:
 ###                                  Proto                                  ###
 ###############################################################################
 
-protoVer=0.11.6
+protoVer=0.12.1
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 containerProtoGen=proto-gen-$(protoVer)
 containerProtoFmt=proto-fmt-$(protoVer)

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -188,7 +188,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 		appKeepers.AccountKeeper,
 	)
 
-	appKeepers.StakingMiddlewareKeeper = stakingmiddleware.NewKeeper(appCodec, appKeepers.keys[stakingmiddlewaretypes.StoreKey], authtypes.NewModuleAddress(govtypes.ModuleName).String())
+	appKeepers.StakingMiddlewareKeeper = stakingmiddleware.NewKeeper(appCodec, appKeepers.keys[stakingmiddlewaretypes.StoreKey], appKeepers.AccountKeeper, appKeepers.BankKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	appKeepers.StakingKeeper = customstaking.NewKeeper(
 		appCodec, appKeepers.keys[stakingtypes.StoreKey], appKeepers.AccountKeeper, appKeepers.BankKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String(), &appKeepers.StakingMiddlewareKeeper,
@@ -238,6 +238,7 @@ func (appKeepers *AppKeepers) InitNormalKeepers(
 	)
 
 	appKeepers.BankKeeper.RegisterKeepers(appKeepers.AllianceKeeper, appKeepers.StakingKeeper)
+	appKeepers.StakingMiddlewareKeeper.RegisterKeepers(appKeepers.StakingKeeper)
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	appKeepers.StakingKeeper.SetHooks(

--- a/app/upgrades/v6_4/upgrade.go
+++ b/app/upgrades/v6_4/upgrade.go
@@ -20,7 +20,7 @@ func CreateUpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		// Add params for custom middleware
-		custommiddlewareparams := customstmiddleware.Params{BlocksPerEpoch: 100, AllowUnbondAfterEpochProgressBlockNumber: 0}
+		custommiddlewareparams := customstmiddleware.Params{BlocksPerEpoch: 360, AllowUnbondAfterEpochProgressBlockNumber: 0}
 		keepers.StakingMiddlewareKeeper.SetParams(ctx, custommiddlewareparams)
 
 		return mm.RunMigrations(ctx, configurator, vm)

--- a/proto/composable/stakingmiddleware/v1beta1/tx.proto
+++ b/proto/composable/stakingmiddleware/v1beta1/tx.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package composable.stakingmiddleware.v1beta1;
 
+import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/msg/v1/msg.proto";
 import "amino/amino.proto";
 import "gogoproto/gogo.proto";
@@ -14,6 +15,7 @@ service Msg {
   option (cosmos.msg.v1.service) = true;
 
   rpc UpdateEpochParams(MsgUpdateEpochParams) returns (MsgUpdateParamsEpochResponse);
+  rpc AddRevenueFundsToStaking(MsgAddRevenueFundsToStakingParams) returns (MsgAddRevenueFundsToStakingResponse);
 }
 
 // MsgUpdateParams is the Msg/UpdateParams request type.
@@ -39,3 +41,16 @@ message MsgUpdateEpochParams {
 //
 // Since: cosmos-sdk 0.47
 message MsgUpdateParamsEpochResponse {}
+
+message MsgAddRevenueFundsToStakingParams {
+  option (cosmos.msg.v1.signer) = "from_address";
+
+  string from_address = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+  repeated cosmos.base.v1beta1.Coin amount = 3 [
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+message MsgAddRevenueFundsToStakingResponse {}

--- a/scripts/testnode.sh
+++ b/scripts/testnode.sh
@@ -11,7 +11,7 @@ LOGLEVEL="info"
 TRACE=""
 
 # remove existing daemon
-rm -rf ~/.centauri*
+rm -rf ~/.banksy*
 
 centaurid config keyring-backend $KEYRING
 centaurid config chain-id $CHAINID
@@ -39,7 +39,7 @@ fi
 
 # update request max size so that we can upload the light client
 # '' -e is a must have params on mac, if use linux please delete before run
-sed -i'' -e 's/max_body_bytes = /max_body_bytes = 1/g' ~/.centauri/config/config.toml
+sed -i'' -e 's/max_body_bytes = /max_body_bytes = 1/g' ~/.banksy/config/config.toml
 
 # Start the node (remove the --pruning=nothing flag if historical queries are not needed)
 centaurid start --pruning=nothing  --minimum-gas-prices=0.0001stake --rpc.laddr tcp://0.0.0.0:26657

--- a/x/stakingmiddleware/client/cli/tx.go
+++ b/x/stakingmiddleware/client/cli/tx.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/spf13/cobra"
-
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	"github.com/spf13/cobra"
 )
 
 // GetTxCmd returns the tx commands for staking middleware module.
@@ -17,7 +19,37 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	txCmd.AddCommand()
+	txCmd.AddCommand(
+		GetCmdAddRevenueFundsToStaking(),
+	)
 
 	return txCmd
+}
+
+func GetCmdAddRevenueFundsToStaking() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "add-revenue [amount]",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			coins, err := sdk.ParseCoinsNormalized(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := &types.MsgAddRevenueFundsToStakingParams{
+				FromAddress: clientCtx.GetFromAddress().String(),
+				Amount:      coins,
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
 }

--- a/x/stakingmiddleware/keeper/keeper.go
+++ b/x/stakingmiddleware/keeper/keeper.go
@@ -9,12 +9,17 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	banktypes "github.com/notional-labs/composable/v6/custom/bank/types"
 )
 
 // Keeper of the staking middleware store
 type Keeper struct {
-	cdc      codec.BinaryCodec
-	storeKey storetypes.StoreKey
+	cdc           codec.BinaryCodec
+	storeKey      storetypes.StoreKey
+	accountKeeper types.AccountKeeper
+	bankKeeper    types.BankKeeper
+	stakingKeeper banktypes.StakingKeeper
 	// the address capable of executing a MsgUpdateParams message. Typically, this
 	// should be the x/gov module account.
 	authority string
@@ -24,13 +29,22 @@ type Keeper struct {
 func NewKeeper(
 	cdc codec.BinaryCodec,
 	key storetypes.StoreKey,
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
 	authority string,
 ) Keeper {
 	return Keeper{
-		cdc:       cdc,
-		storeKey:  key,
-		authority: authority,
+		cdc:           cdc,
+		storeKey:      key,
+		accountKeeper: ak,
+		bankKeeper:    bk,
+		stakingKeeper: stakingkeeper.Keeper{},
+		authority:     authority,
 	}
+}
+
+func (k *Keeper) RegisterKeepers(sk banktypes.StakingKeeper) {
+	k.stakingKeeper = sk
 }
 
 // GetAuthority returns the x/stakingmiddleware module's authority.
@@ -73,4 +87,9 @@ func (k Keeper) GetParams(ctx sdk.Context) (p types.Params) {
 
 	k.cdc.MustUnmarshal(bz, &p)
 	return p
+}
+
+func (k Keeper) GetModuleAccountAccAddress(ctx sdk.Context) sdk.AccAddress {
+	moduleAccount := k.accountKeeper.GetModuleAccount(ctx, types.RewardModuleName)
+	return moduleAccount.GetAddress()
 }

--- a/x/stakingmiddleware/types/errors.go
+++ b/x/stakingmiddleware/types/errors.go
@@ -1,0 +1,7 @@
+package types
+
+import (
+	errorsmod "cosmossdk.io/errors"
+)
+
+var ErrInvalidCoin = errorsmod.Register(ModuleName, 1, "invalid coin")

--- a/x/stakingmiddleware/types/expected_keepers.go
+++ b/x/stakingmiddleware/types/expected_keepers.go
@@ -1,0 +1,17 @@
+package types // noalias
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// AccountKeeper defines the contract required for account APIs.
+type AccountKeeper interface {
+	GetModuleAccount(ctx sdk.Context, moduleName string) types.ModuleAccountI
+}
+
+// BankKeeper defines the contract needed to be fulfilled for banking and supply
+// dependencies.
+type BankKeeper interface {
+	SendCoins(ctx sdk.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
+}

--- a/x/stakingmiddleware/types/genesis.go
+++ b/x/stakingmiddleware/types/genesis.go
@@ -10,7 +10,7 @@ func NewGenesisState(params Params) *GenesisState {
 // DefaultGenesisState creates a default GenesisState object
 func DefaultGenesisState() *GenesisState {
 	return &GenesisState{
-		Params: Params{BlocksPerEpoch: 10, AllowUnbondAfterEpochProgressBlockNumber: 0},
+		Params: Params{BlocksPerEpoch: 360, AllowUnbondAfterEpochProgressBlockNumber: 0},
 	}
 }
 

--- a/x/stakingmiddleware/types/keys.go
+++ b/x/stakingmiddleware/types/keys.go
@@ -2,12 +2,14 @@ package types
 
 // ParamsKey is the key to use for the keeper store.
 var (
-	ParamsKey = []byte{0x01} // key for global staking middleware params in the keeper store
+	ParamsKey      = []byte{0x01} // key for global staking middleware params in the keeper store
+	RewardDenomKey = []byte{0x02}
 )
 
 const (
 	// module name
-	ModuleName = "stakingmiddleware"
+	ModuleName       = "stakingmiddleware"
+	RewardModuleName = "fee_collector"
 
 	// StoreKey is the default store key for stakingmiddleware module that store params when apply validator set changes and when allow to unbond/redelegate
 

--- a/x/stakingmiddleware/types/keys.go
+++ b/x/stakingmiddleware/types/keys.go
@@ -2,8 +2,7 @@ package types
 
 // ParamsKey is the key to use for the keeper store.
 var (
-	ParamsKey      = []byte{0x01} // key for global staking middleware params in the keeper store
-	RewardDenomKey = []byte{0x02}
+	ParamsKey = []byte{0x01} // key for global staking middleware params in the keeper store
 )
 
 const (

--- a/x/stakingmiddleware/types/msgs.go
+++ b/x/stakingmiddleware/types/msgs.go
@@ -26,3 +26,23 @@ func (m *MsgUpdateEpochParams) ValidateBasic() error {
 
 	return nil
 }
+
+// GetSignBytes implements the LegacyMsg interface.
+func (m MsgAddRevenueFundsToStakingParams) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&m))
+}
+
+// GetSigners returns the expected signers for a MsgUpdateParams message.
+func (m *MsgAddRevenueFundsToStakingParams) GetSigners() []sdk.AccAddress {
+	addr, _ := sdk.AccAddressFromBech32(m.FromAddress)
+	return []sdk.AccAddress{addr}
+}
+
+// ValidateBasic does a sanity check on the provided data.
+func (m *MsgAddRevenueFundsToStakingParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(m.FromAddress); err != nil {
+		return errorsmod.Wrapf(err, "invalid address")
+	}
+
+	return nil
+}

--- a/x/stakingmiddleware/types/tx.pb.go
+++ b/x/stakingmiddleware/types/tx.pb.go
@@ -7,6 +7,8 @@ import (
 	context "context"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
+	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
+	types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/cosmos/cosmos-sdk/types/msgservice"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
@@ -131,9 +133,99 @@ func (m *MsgUpdateParamsEpochResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgUpdateParamsEpochResponse proto.InternalMessageInfo
 
+type MsgAddRevenueFundsToStakingParams struct {
+	FromAddress string                                   `protobuf:"bytes,1,opt,name=from_address,json=fromAddress,proto3" json:"from_address,omitempty"`
+	Amount      github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,3,rep,name=amount,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"amount"`
+}
+
+func (m *MsgAddRevenueFundsToStakingParams) Reset()         { *m = MsgAddRevenueFundsToStakingParams{} }
+func (m *MsgAddRevenueFundsToStakingParams) String() string { return proto.CompactTextString(m) }
+func (*MsgAddRevenueFundsToStakingParams) ProtoMessage()    {}
+func (*MsgAddRevenueFundsToStakingParams) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4ef8bcd16d104cd6, []int{2}
+}
+func (m *MsgAddRevenueFundsToStakingParams) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgAddRevenueFundsToStakingParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgAddRevenueFundsToStakingParams.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgAddRevenueFundsToStakingParams) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgAddRevenueFundsToStakingParams.Merge(m, src)
+}
+func (m *MsgAddRevenueFundsToStakingParams) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgAddRevenueFundsToStakingParams) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgAddRevenueFundsToStakingParams.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgAddRevenueFundsToStakingParams proto.InternalMessageInfo
+
+func (m *MsgAddRevenueFundsToStakingParams) GetFromAddress() string {
+	if m != nil {
+		return m.FromAddress
+	}
+	return ""
+}
+
+func (m *MsgAddRevenueFundsToStakingParams) GetAmount() github_com_cosmos_cosmos_sdk_types.Coins {
+	if m != nil {
+		return m.Amount
+	}
+	return nil
+}
+
+type MsgAddRevenueFundsToStakingResponse struct {
+}
+
+func (m *MsgAddRevenueFundsToStakingResponse) Reset()         { *m = MsgAddRevenueFundsToStakingResponse{} }
+func (m *MsgAddRevenueFundsToStakingResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgAddRevenueFundsToStakingResponse) ProtoMessage()    {}
+func (*MsgAddRevenueFundsToStakingResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4ef8bcd16d104cd6, []int{3}
+}
+func (m *MsgAddRevenueFundsToStakingResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgAddRevenueFundsToStakingResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgAddRevenueFundsToStakingResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgAddRevenueFundsToStakingResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgAddRevenueFundsToStakingResponse.Merge(m, src)
+}
+func (m *MsgAddRevenueFundsToStakingResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgAddRevenueFundsToStakingResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgAddRevenueFundsToStakingResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgAddRevenueFundsToStakingResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgUpdateEpochParams)(nil), "composable.stakingmiddleware.v1beta1.MsgUpdateEpochParams")
 	proto.RegisterType((*MsgUpdateParamsEpochResponse)(nil), "composable.stakingmiddleware.v1beta1.MsgUpdateParamsEpochResponse")
+	proto.RegisterType((*MsgAddRevenueFundsToStakingParams)(nil), "composable.stakingmiddleware.v1beta1.MsgAddRevenueFundsToStakingParams")
+	proto.RegisterType((*MsgAddRevenueFundsToStakingResponse)(nil), "composable.stakingmiddleware.v1beta1.MsgAddRevenueFundsToStakingResponse")
 }
 
 func init() {
@@ -141,30 +233,40 @@ func init() {
 }
 
 var fileDescriptor_4ef8bcd16d104cd6 = []byte{
-	// 362 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xd2, 0x4d, 0xce, 0xcf, 0x2d,
-	0xc8, 0x2f, 0x4e, 0x4c, 0xca, 0x49, 0xd5, 0x2f, 0x2e, 0x49, 0xcc, 0xce, 0xcc, 0x4b, 0xcf, 0xcd,
-	0x4c, 0x49, 0xc9, 0x49, 0x2d, 0x4f, 0x2c, 0x4a, 0xd5, 0x2f, 0x33, 0x4c, 0x4a, 0x2d, 0x49, 0x34,
-	0xd4, 0x2f, 0xa9, 0xd0, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x52, 0x41, 0x28, 0xd7, 0xc3, 0x50,
-	0xae, 0x07, 0x55, 0x2e, 0x25, 0x9e, 0x9c, 0x5f, 0x9c, 0x9b, 0x5f, 0xac, 0x9f, 0x5b, 0x9c, 0xae,
-	0x5f, 0x66, 0x08, 0xa2, 0x20, 0xda, 0xa5, 0x04, 0x13, 0x73, 0x33, 0xf3, 0xf2, 0xf5, 0xc1, 0x24,
-	0x54, 0x48, 0x24, 0x3d, 0x3f, 0x3d, 0x1f, 0xcc, 0xd4, 0x07, 0xb1, 0xa0, 0xa2, 0x92, 0x10, 0x13,
-	0xe2, 0x21, 0x12, 0x10, 0x0e, 0x54, 0xca, 0x86, 0x28, 0x17, 0x63, 0x3a, 0x0e, 0xac, 0x5b, 0xe9,
-	0x11, 0x23, 0x97, 0x88, 0x6f, 0x71, 0x7a, 0x68, 0x41, 0x4a, 0x62, 0x49, 0xaa, 0x6b, 0x41, 0x7e,
-	0x72, 0x46, 0x40, 0x62, 0x51, 0x62, 0x6e, 0xb1, 0x90, 0x19, 0x17, 0x67, 0x62, 0x69, 0x49, 0x46,
-	0x7e, 0x51, 0x66, 0x49, 0xa5, 0x04, 0xa3, 0x02, 0xa3, 0x06, 0xa7, 0x93, 0xc4, 0xa5, 0x2d, 0xba,
-	0x22, 0x50, 0xbb, 0x1d, 0x53, 0x52, 0x8a, 0x52, 0x8b, 0x8b, 0x83, 0x4b, 0x8a, 0x32, 0xf3, 0xd2,
-	0x83, 0x10, 0x4a, 0x85, 0xfc, 0xb9, 0xd8, 0x0a, 0xc0, 0x26, 0x48, 0x30, 0x29, 0x30, 0x6a, 0x70,
-	0x1b, 0xe9, 0xe8, 0x11, 0x13, 0x44, 0x7a, 0x10, 0x5b, 0x9d, 0x38, 0x4f, 0xdc, 0x93, 0x67, 0x58,
-	0xf1, 0x7c, 0x83, 0x16, 0x63, 0x10, 0xd4, 0x18, 0x2b, 0xc7, 0xa6, 0xe7, 0x1b, 0xb4, 0x10, 0x16,
-	0x74, 0x3d, 0xdf, 0xa0, 0x85, 0x64, 0xa4, 0x7e, 0x05, 0x16, 0x4f, 0xc3, 0x3d, 0x04, 0x31, 0x55,
-	0x49, 0x8e, 0x4b, 0x06, 0x4d, 0x08, 0xec, 0xd3, 0xa0, 0xd4, 0xe2, 0x82, 0xfc, 0xbc, 0xe2, 0x54,
-	0xa3, 0x45, 0x8c, 0x5c, 0xcc, 0xbe, 0xc5, 0xe9, 0x42, 0x93, 0x19, 0xb9, 0x04, 0x31, 0x43, 0xc2,
-	0x8a, 0x38, 0x1f, 0x60, 0x0b, 0x45, 0x29, 0x27, 0x12, 0xf5, 0x62, 0x71, 0x9d, 0x14, 0x6b, 0x03,
-	0x28, 0x3c, 0x9c, 0x8c, 0x4f, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39,
-	0xc6, 0x09, 0x8f, 0xe5, 0x18, 0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1, 0x58, 0x8e, 0x21, 0x4a, 0x12,
-	0x5b, 0x18, 0x94, 0x54, 0x16, 0xa4, 0x16, 0x27, 0xb1, 0x81, 0x63, 0xd9, 0x18, 0x10, 0x00, 0x00,
-	0xff, 0xff, 0xc4, 0xc6, 0x61, 0xc6, 0xd7, 0x02, 0x00, 0x00,
+	// 522 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0x4d, 0x8f, 0xd2, 0x40,
+	0x18, 0x66, 0x96, 0x48, 0xc2, 0xe0, 0x85, 0x86, 0xc4, 0xd2, 0x98, 0x2e, 0xa2, 0x26, 0x84, 0x48,
+	0x1b, 0xd8, 0xe8, 0x01, 0xbd, 0x50, 0xa3, 0xc6, 0x03, 0xd1, 0xb0, 0x7a, 0xf1, 0xb2, 0x99, 0xd2,
+	0xb1, 0x34, 0xbb, 0x9d, 0x69, 0xfa, 0x4e, 0x71, 0xf7, 0x66, 0x3c, 0x7a, 0x32, 0xf1, 0x4f, 0x18,
+	0x0f, 0x86, 0x83, 0x3f, 0x62, 0x8f, 0x1b, 0xbd, 0x78, 0xf1, 0x23, 0x70, 0xe0, 0x6f, 0x98, 0x76,
+	0x66, 0x17, 0x15, 0x44, 0xcc, 0x5e, 0x98, 0xe1, 0xfd, 0x78, 0xde, 0x79, 0x9e, 0xe7, 0x2d, 0x6e,
+	0x0d, 0x79, 0x18, 0x71, 0x20, 0xee, 0x01, 0xb5, 0x41, 0x90, 0xfd, 0x80, 0xf9, 0x61, 0xe0, 0x79,
+	0x07, 0xf4, 0x05, 0x89, 0xa9, 0x3d, 0x6e, 0xbb, 0x54, 0x90, 0xb6, 0x2d, 0x0e, 0xad, 0x28, 0xe6,
+	0x82, 0x6b, 0xd7, 0x16, 0xe5, 0xd6, 0x52, 0xb9, 0xa5, 0xca, 0x0d, 0x73, 0xc8, 0x21, 0xe4, 0x60,
+	0xbb, 0x04, 0x16, 0x18, 0x43, 0x1e, 0x30, 0x89, 0x62, 0x5c, 0x52, 0xf9, 0x10, 0x7c, 0x7b, 0xdc,
+	0x4e, 0x0f, 0x95, 0x28, 0x93, 0x30, 0x60, 0xdc, 0xce, 0x7e, 0x55, 0xa8, 0xe2, 0x73, 0x9f, 0x67,
+	0x57, 0x3b, 0xbd, 0xa9, 0x68, 0x55, 0x22, 0xec, 0xc9, 0x84, 0xfc, 0xa3, 0x52, 0x77, 0x36, 0x62,
+	0xb4, 0xfc, 0xf8, 0xac, 0xbb, 0x3e, 0x45, 0xb8, 0xd2, 0x07, 0xff, 0x69, 0xe4, 0x11, 0x41, 0xef,
+	0x45, 0x7c, 0x38, 0x7a, 0x4c, 0x62, 0x12, 0x82, 0x76, 0x0b, 0x17, 0x49, 0x22, 0x46, 0x3c, 0x0e,
+	0xc4, 0x91, 0x8e, 0x6a, 0xa8, 0x51, 0x74, 0xf4, 0x4f, 0x1f, 0x5b, 0x15, 0x35, 0xbb, 0xe7, 0x79,
+	0x31, 0x05, 0xd8, 0x15, 0x71, 0xc0, 0xfc, 0xc1, 0xa2, 0x54, 0x7b, 0x84, 0x0b, 0x51, 0x86, 0xa0,
+	0x6f, 0xd5, 0x50, 0xa3, 0xd4, 0xb9, 0x61, 0x6d, 0x22, 0xa1, 0x25, 0xa7, 0x3a, 0xc5, 0xe3, 0x6f,
+	0xdb, 0xb9, 0x77, 0xf3, 0x49, 0x13, 0x0d, 0x14, 0x4c, 0xb7, 0xf7, 0x6a, 0x3e, 0x69, 0x2e, 0x06,
+	0xbc, 0x9e, 0x4f, 0x9a, 0xbf, 0x40, 0xda, 0x87, 0x2b, 0x48, 0x9f, 0x11, 0x92, 0xa8, 0x75, 0x13,
+	0x5f, 0xfe, 0x23, 0x94, 0x31, 0x1d, 0x50, 0x88, 0x38, 0x03, 0x5a, 0xff, 0x8a, 0xf0, 0x95, 0x3e,
+	0xf8, 0x3d, 0xcf, 0x1b, 0xd0, 0x31, 0x65, 0x09, 0xbd, 0x9f, 0x30, 0x0f, 0x9e, 0xf0, 0x5d, 0x89,
+	0xac, 0x14, 0xb9, 0x8d, 0x2f, 0x3e, 0x8f, 0x79, 0xb8, 0x47, 0x24, 0xf5, 0x7f, 0x8a, 0x52, 0x4a,
+	0xab, 0x55, 0x48, 0x1b, 0xe1, 0x02, 0x09, 0x79, 0xc2, 0x84, 0x9e, 0xaf, 0xe5, 0x1b, 0xa5, 0x4e,
+	0xd5, 0x52, 0x3d, 0xe9, 0xce, 0x9c, 0xa9, 0x70, 0x97, 0x07, 0xcc, 0xb9, 0x99, 0x6a, 0xf0, 0xfe,
+	0xfb, 0x76, 0xc3, 0x0f, 0xc4, 0x28, 0x71, 0x53, 0xb2, 0xca, 0x71, 0x75, 0xb4, 0xc0, 0xdb, 0xb7,
+	0xc5, 0x51, 0x44, 0x21, 0x6b, 0x00, 0xa5, 0x97, 0xc4, 0xef, 0x96, 0x53, 0xbd, 0x7e, 0x7b, 0x69,
+	0xfd, 0x3a, 0xbe, 0xba, 0x86, 0xde, 0xa9, 0x0c, 0x9d, 0xcf, 0x5b, 0x38, 0xdf, 0x07, 0x5f, 0x7b,
+	0x8b, 0x70, 0x79, 0x79, 0x21, 0xba, 0x9b, 0x19, 0xb9, 0x6a, 0x99, 0x0c, 0xe7, 0x3f, 0x7b, 0x57,
+	0x98, 0xa4, 0x7d, 0x40, 0x58, 0xff, 0x1b, 0x05, 0xed, 0xc1, 0xc6, 0x03, 0xd6, 0x9b, 0x6c, 0x3c,
+	0x3c, 0x37, 0xd0, 0xe9, 0x83, 0x8d, 0x0b, 0x2f, 0x53, 0x5f, 0x9c, 0x9d, 0xe3, 0xa9, 0x89, 0x4e,
+	0xa6, 0x26, 0xfa, 0x31, 0x35, 0xd1, 0x9b, 0x99, 0x99, 0x3b, 0x99, 0x99, 0xb9, 0x2f, 0x33, 0x33,
+	0xf7, 0xac, 0xba, 0x6a, 0x77, 0x33, 0x5f, 0xdd, 0x42, 0xf6, 0x75, 0xee, 0xfc, 0x0c, 0x00, 0x00,
+	0xff, 0xff, 0x00, 0xe0, 0x13, 0xf7, 0xaf, 0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -180,6 +282,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
 	UpdateEpochParams(ctx context.Context, in *MsgUpdateEpochParams, opts ...grpc.CallOption) (*MsgUpdateParamsEpochResponse, error)
+	AddRevenueFundsToStaking(ctx context.Context, in *MsgAddRevenueFundsToStakingParams, opts ...grpc.CallOption) (*MsgAddRevenueFundsToStakingResponse, error)
 }
 
 type msgClient struct {
@@ -199,9 +302,19 @@ func (c *msgClient) UpdateEpochParams(ctx context.Context, in *MsgUpdateEpochPar
 	return out, nil
 }
 
+func (c *msgClient) AddRevenueFundsToStaking(ctx context.Context, in *MsgAddRevenueFundsToStakingParams, opts ...grpc.CallOption) (*MsgAddRevenueFundsToStakingResponse, error) {
+	out := new(MsgAddRevenueFundsToStakingResponse)
+	err := c.cc.Invoke(ctx, "/composable.stakingmiddleware.v1beta1.Msg/AddRevenueFundsToStaking", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	UpdateEpochParams(context.Context, *MsgUpdateEpochParams) (*MsgUpdateParamsEpochResponse, error)
+	AddRevenueFundsToStaking(context.Context, *MsgAddRevenueFundsToStakingParams) (*MsgAddRevenueFundsToStakingResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -210,6 +323,9 @@ type UnimplementedMsgServer struct {
 
 func (*UnimplementedMsgServer) UpdateEpochParams(ctx context.Context, req *MsgUpdateEpochParams) (*MsgUpdateParamsEpochResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateEpochParams not implemented")
+}
+func (*UnimplementedMsgServer) AddRevenueFundsToStaking(ctx context.Context, req *MsgAddRevenueFundsToStakingParams) (*MsgAddRevenueFundsToStakingResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddRevenueFundsToStaking not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -234,6 +350,24 @@ func _Msg_UpdateEpochParams_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_AddRevenueFundsToStaking_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgAddRevenueFundsToStakingParams)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).AddRevenueFundsToStaking(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/composable.stakingmiddleware.v1beta1.Msg/AddRevenueFundsToStaking",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).AddRevenueFundsToStaking(ctx, req.(*MsgAddRevenueFundsToStakingParams))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "composable.stakingmiddleware.v1beta1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -241,6 +375,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateEpochParams",
 			Handler:    _Msg_UpdateEpochParams_Handler,
+		},
+		{
+			MethodName: "AddRevenueFundsToStaking",
+			Handler:    _Msg_AddRevenueFundsToStaking_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -310,6 +448,73 @@ func (m *MsgUpdateParamsEpochResponse) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgAddRevenueFundsToStakingParams) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgAddRevenueFundsToStakingParams) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgAddRevenueFundsToStakingParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Amount) > 0 {
+		for iNdEx := len(m.Amount) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Amount[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.FromAddress) > 0 {
+		i -= len(m.FromAddress)
+		copy(dAtA[i:], m.FromAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.FromAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgAddRevenueFundsToStakingResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgAddRevenueFundsToStakingResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgAddRevenueFundsToStakingResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -337,6 +542,34 @@ func (m *MsgUpdateEpochParams) Size() (n int) {
 }
 
 func (m *MsgUpdateParamsEpochResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgAddRevenueFundsToStakingParams) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.FromAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.Amount) > 0 {
+		for _, e := range m.Amount {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *MsgAddRevenueFundsToStakingResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -493,6 +726,172 @@ func (m *MsgUpdateParamsEpochResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgUpdateParamsEpochResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgAddRevenueFundsToStakingParams) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgAddRevenueFundsToStakingParams: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgAddRevenueFundsToStakingParams: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FromAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.FromAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Amount = append(m.Amount, types.Coin{})
+			if err := m.Amount[len(m.Amount)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgAddRevenueFundsToStakingResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgAddRevenueFundsToStakingResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgAddRevenueFundsToStakingResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
change proto-gen docker image versio to 0.12.1 to support go 1.20 and tidy

Changed stakingmiddleware module:

added transaction to transfer to fee_collector from signer
added 3 keepers to the module's keeper struct - AccountKeeper to get module account and BankKeeper to send coin to the module, StakingKeeper to get BondDenom
