### PR TITLE
rename module

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -4,15 +4,15 @@ import (
 	ibcante "github.com/cosmos/ibc-go/v7/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 
+	tfmwKeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
+	txBoundaryAnte "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/ante"
+	txBoundaryKeeper "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/keeper"
 	"github.com/cosmos/cosmos-sdk/codec"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	tfmwKeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
-	txBoundaryAnte "github.com/notional-labs/composable/v6/x/tx-boundary/ante"
-	txBoundaryKeeper "github.com/notional-labs/composable/v6/x/tx-boundary/keeper"
 )
 
 // Link to default ante handler used by cosmos sdk:

--- a/app/ante/ibc_ante.go
+++ b/app/ante/ibc_ante.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 
-	tfmwKeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	tfmwKeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 )
 
 type IBCPermissionDecorator struct {

--- a/app/app.go
+++ b/app/app.go
@@ -35,8 +35,8 @@ import (
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades/v6_5_0"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades/v6_5_0"
 
 	// bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
@@ -74,6 +74,8 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 
+	customibctransfer "github.com/ComposableFi/composable-cosmos/v6/custom/ibc-transfer"
+	customstaking "github.com/ComposableFi/composable-cosmos/v6/custom/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
@@ -87,8 +89,6 @@ import (
 	ibcclientclient "github.com/cosmos/ibc-go/v7/modules/core/02-client/client"
 	ibchost "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
-	customibctransfer "github.com/notional-labs/composable/v6/custom/ibc-transfer"
-	customstaking "github.com/notional-labs/composable/v6/custom/staking"
 	"github.com/spf13/cast"
 	icq "github.com/strangelove-ventures/async-icq/v7"
 	icqtypes "github.com/strangelove-ventures/async-icq/v7/types"
@@ -99,37 +99,37 @@ import (
 	alliancemoduleclient "github.com/terra-money/alliance/x/alliance/client"
 	alliancemoduletypes "github.com/terra-money/alliance/x/alliance/types"
 
-	custombankmodule "github.com/notional-labs/composable/v6/custom/bank"
+	custombankmodule "github.com/ComposableFi/composable-cosmos/v6/custom/bank"
 
-	"github.com/notional-labs/composable/v6/app/ante"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware"
-	transfermiddleware "github.com/notional-labs/composable/v6/x/transfermiddleware"
-	transfermiddlewaretypes "github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/app/ante"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware"
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware"
+	transfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware"
+	transfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 
-	txBoundary "github.com/notional-labs/composable/v6/x/tx-boundary"
-	txBoundaryTypes "github.com/notional-labs/composable/v6/x/tx-boundary/types"
+	txBoundary "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary"
+	txBoundaryTypes "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 
-	ratelimitmodule "github.com/notional-labs/composable/v6/x/ratelimit"
-	ratelimitmoduletypes "github.com/notional-labs/composable/v6/x/ratelimit/types"
+	ratelimitmodule "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit"
+	ratelimitmoduletypes "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 
-	"github.com/notional-labs/composable/v6/x/mint"
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 
 	ibctestingtypes "github.com/cosmos/ibc-go/v7/testing/types"
 
-	ibc_hooks "github.com/notional-labs/composable/v6/x/ibc-hooks"
-	ibchookstypes "github.com/notional-labs/composable/v6/x/ibc-hooks/types"
+	ibc_hooks "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks"
+	ibchookstypes "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	upgrades "github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddlewaretypes "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
-	stakingmiddlewaretypes "github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	upgrades "github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
+	stakingmiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 )
 
 const (

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cosmos/ibc-go/v7/testing/mock"
 	"github.com/stretchr/testify/require"
 
-	composable "github.com/notional-labs/composable/v6/app"
+	composable "github.com/ComposableFi/composable-cosmos/v6/app"
 )
 
 // SimAppChainID hardcoded chainID for simulation

--- a/app/ibctesting/chain.go
+++ b/app/ibctesting/chain.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	ratelimitmodulekeeper "github.com/notional-labs/composable/v6/x/ratelimit/keeper"
+	ratelimitmodulekeeper "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
 
 	"cosmossdk.io/errors"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -54,9 +54,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	composable "github.com/notional-labs/composable/v6/app"
-	"github.com/notional-labs/composable/v6/app/ibctesting/simapp"
-	routerKeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	composable "github.com/ComposableFi/composable-cosmos/v6/app"
+	"github.com/ComposableFi/composable-cosmos/v6/app/ibctesting/simapp"
+	routerKeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 )
 
 // TestChain is a testing struct that wraps a simapp with the last TM Header, the current ABCI

--- a/app/ibctesting/simapp/app.go
+++ b/app/ibctesting/simapp/app.go
@@ -90,9 +90,9 @@ import (
 	"github.com/gorilla/mux"
 
 	// TODO: mint module not complete yet,
-	"github.com/notional-labs/composable/v6/x/mint"
-	mintkeeper "github.com/notional-labs/composable/v6/x/mint/keeper"
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint"
+	mintkeeper "github.com/ComposableFi/composable-cosmos/v6/x/mint/keeper"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
@@ -124,13 +124,13 @@ import (
 	ibcmock "github.com/cosmos/ibc-go/v7/testing/mock"
 	ibctestingtypes "github.com/cosmos/ibc-go/v7/testing/types"
 
-	simappparams "github.com/notional-labs/composable/v6/app/ibctesting/simapp/params"
-	simappupgrades "github.com/notional-labs/composable/v6/app/ibctesting/simapp/upgrades"
-	v6 "github.com/notional-labs/composable/v6/app/ibctesting/simapp/upgrades/v6"
-	v7 "github.com/notional-labs/composable/v6/app/ibctesting/simapp/upgrades/v7"
-	transfermiddleware "github.com/notional-labs/composable/v6/x/transfermiddleware"
-	transfermiddlewarekeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
-	transfermiddlewaretypes "github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	simappparams "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting/simapp/params"
+	simappupgrades "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting/simapp/upgrades"
+	v6 "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting/simapp/upgrades/v6"
+	v7 "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting/simapp/upgrades/v7"
+	transfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware"
+	transfermiddlewarekeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
+	transfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 const appName = "SimApp"

--- a/app/ibctesting/simapp/encoding.go
+++ b/app/ibctesting/simapp/encoding.go
@@ -3,7 +3,7 @@ package simapp
 import (
 	"github.com/cosmos/cosmos-sdk/std"
 
-	simappparams "github.com/notional-labs/composable/v6/app/ibctesting/simapp/params"
+	simappparams "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting/simapp/params"
 )
 
 // MakeTestEncodingConfig creates an EncodingConfig for testing. This function

--- a/app/ibctesting/simapp/sim_test.go
+++ b/app/ibctesting/simapp/sim_test.go
@@ -30,7 +30,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
 
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -45,8 +45,8 @@ import (
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 
+	customstaking "github.com/ComposableFi/composable-cosmos/v6/custom/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	customstaking "github.com/notional-labs/composable/v6/custom/staking/keeper"
 
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
@@ -58,17 +58,17 @@ import (
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer"
 
+	customibctransferkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/ibc-transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ibcclient "github.com/cosmos/ibc-go/v7/modules/core/02-client"
 	ibcclienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	ibchost "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
-	customibctransferkeeper "github.com/notional-labs/composable/v6/custom/ibc-transfer/keeper"
 	icq "github.com/strangelove-ventures/async-icq/v7"
 	icqkeeper "github.com/strangelove-ventures/async-icq/v7/keeper"
 	icqtypes "github.com/strangelove-ventures/async-icq/v7/types"
 
-	custombankkeeper "github.com/notional-labs/composable/v6/custom/bank/keeper"
+	custombankkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/bank/keeper"
 
 	router "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward"
 	routerkeeper "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward/keeper"
@@ -78,22 +78,22 @@ import (
 	alliancemodulekeeper "github.com/terra-money/alliance/x/alliance/keeper"
 	alliancemoduletypes "github.com/terra-money/alliance/x/alliance/types"
 
-	transfermiddleware "github.com/notional-labs/composable/v6/x/transfermiddleware"
-	transfermiddlewarekeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
-	transfermiddlewaretypes "github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	transfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware"
+	transfermiddlewarekeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
+	transfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 
-	txBoundaryKeeper "github.com/notional-labs/composable/v6/x/tx-boundary/keeper"
-	txBoundaryTypes "github.com/notional-labs/composable/v6/x/tx-boundary/types"
+	txBoundaryKeeper "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/keeper"
+	txBoundaryTypes "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 
-	ratelimitmodule "github.com/notional-labs/composable/v6/x/ratelimit"
-	ratelimitmodulekeeper "github.com/notional-labs/composable/v6/x/ratelimit/keeper"
-	ratelimitmoduletypes "github.com/notional-labs/composable/v6/x/ratelimit/types"
+	ratelimitmodule "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit"
+	ratelimitmodulekeeper "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
+	ratelimitmoduletypes "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 
 	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 
-	mintkeeper "github.com/notional-labs/composable/v6/x/mint/keeper"
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	mintkeeper "github.com/ComposableFi/composable-cosmos/v6/x/mint/keeper"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -102,14 +102,14 @@ import (
 	wasm08Keeper "github.com/cosmos/ibc-go/v7/modules/light-clients/08-wasm/keeper"
 	wasm08types "github.com/cosmos/ibc-go/v7/modules/light-clients/08-wasm/types"
 
-	ibc_hooks "github.com/notional-labs/composable/v6/x/ibc-hooks"
-	ibchookskeeper "github.com/notional-labs/composable/v6/x/ibc-hooks/keeper"
-	ibchookstypes "github.com/notional-labs/composable/v6/x/ibc-hooks/types"
-	stakingmiddleware "github.com/notional-labs/composable/v6/x/stakingmiddleware/keeper"
-	stakingmiddlewaretypes "github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	ibc_hooks "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks"
+	ibchookskeeper "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/keeper"
+	ibchookstypes "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
+	stakingmiddleware "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/keeper"
+	stakingmiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/keeper"
-	ibctransfermiddlewaretypes "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/keeper"
+	ibctransfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 )
 
 const (

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -29,24 +29,24 @@ import (
 	routertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward/types"
 	alliancemoduletypes "github.com/terra-money/alliance/x/alliance/types"
 
-	ibchookstypes "github.com/notional-labs/composable/v6/x/ibc-hooks/types"
-	ratelimitmoduletypes "github.com/notional-labs/composable/v6/x/ratelimit/types"
-	transfermiddlewaretypes "github.com/notional-labs/composable/v6/x/transfermiddleware/types"
-	txBoundaryTypes "github.com/notional-labs/composable/v6/x/tx-boundary/types"
+	ibchookstypes "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
+	ratelimitmoduletypes "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
+	transfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
+	txBoundaryTypes "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasm08types "github.com/cosmos/ibc-go/v7/modules/light-clients/08-wasm/types"
 
-	// customstakingtypes "github.com/notional-labs/composable/v6/custom/staking/types"
-	stakingmiddleware "github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	// customstakingtypes "github.com/ComposableFi/composable-cosmos/v6/custom/staking/types"
+	stakingmiddleware "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 )
 
 // GenerateKeys generates new keys (KV Store, Transient store, and memory store).

--- a/app/test_access.go
+++ b/app/test_access.go
@@ -16,8 +16,8 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 	wasm08 "github.com/cosmos/ibc-go/v7/modules/light-clients/08-wasm/keeper"
 
-	ratelimitkeeper "github.com/notional-labs/composable/v6/x/ratelimit/keeper"
-	tfmdKeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	ratelimitkeeper "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
+	tfmdKeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 )
 
 type TestSupport struct {

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -36,7 +36,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"

--- a/app/upgrades/centauri/upgrade.go
+++ b/app/upgrades/centauri/upgrade.go
@@ -16,10 +16,10 @@ import (
 
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 
-	bech32authmigration "github.com/notional-labs/composable/v6/bech32-migration/auth"
-	bech32govmigration "github.com/notional-labs/composable/v6/bech32-migration/gov"
-	bech32slashingmigration "github.com/notional-labs/composable/v6/bech32-migration/slashing"
-	bech32stakingmigration "github.com/notional-labs/composable/v6/bech32-migration/staking"
+	bech32authmigration "github.com/ComposableFi/composable-cosmos/v6/bech32-migration/auth"
+	bech32govmigration "github.com/ComposableFi/composable-cosmos/v6/bech32-migration/gov"
+	bech32slashingmigration "github.com/ComposableFi/composable-cosmos/v6/bech32-migration/slashing"
+	bech32stakingmigration "github.com/ComposableFi/composable-cosmos/v6/bech32-migration/staking"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/reward/upgrade.go
+++ b/app/upgrades/reward/upgrade.go
@@ -5,8 +5,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	mintkeeper "github.com/notional-labs/composable/v6/x/mint/keeper"
-	tfmwkeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	mintkeeper "github.com/ComposableFi/composable-cosmos/v6/x/mint/keeper"
+	tfmwkeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 )
 
 var listAllowedRelayAddress = []string{

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/notional-labs/composable/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
 )
 
 // BaseAppParamManager defines an interrace that BaseApp is expected to fullfil

--- a/app/upgrades/v4/constants.go
+++ b/app/upgrades/v4/constants.go
@@ -5,9 +5,9 @@ import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibchookstypes "github.com/notional-labs/composable/v6/x/ibc-hooks/types"
-	ratelimitmoduletypes "github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibchookstypes "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
+	ratelimitmoduletypes "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 const (

--- a/app/upgrades/v4/upgrade.go
+++ b/app/upgrades/v4/upgrade.go
@@ -6,10 +6,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	tfmdtypes "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	tfmdtypes "github.com/notional-labs/composable/v6/x/transfermiddleware/types"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v4_5/constants.go
+++ b/app/upgrades/v4_5/constants.go
@@ -1,6 +1,6 @@
 package v45
 
-import "github.com/notional-labs/composable/v6/app/upgrades"
+import "github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 
 const (
 	// UpgradeName defines the on-chain upgrade name for the composable upgrade.

--- a/app/upgrades/v4_5/fork.go
+++ b/app/upgrades/v4_5/fork.go
@@ -12,7 +12,7 @@ import (
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 
-	"github.com/notional-labs/composable/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
 )
 
 func RunForkLogic(ctx sdk.Context, appKeepers *keepers.AppKeepers) {

--- a/app/upgrades/v4_5_1/constants.go
+++ b/app/upgrades/v4_5_1/constants.go
@@ -1,6 +1,6 @@
 package v4_5_1
 
-import "github.com/notional-labs/composable/v6/app/upgrades"
+import "github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 
 const (
 	// UpgradeName defines the on-chain upgrade name for the Composable v5 upgrade.

--- a/app/upgrades/v4_5_1/fork.go
+++ b/app/upgrades/v4_5_1/fork.go
@@ -3,8 +3,8 @@ package v4_5_1
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/app/keepers"
-	rateLimitKeeper "github.com/notional-labs/composable/v6/x/ratelimit/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	rateLimitKeeper "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
 )
 
 func RunForkLogic(ctx sdk.Context, keepers *keepers.AppKeepers) {

--- a/app/upgrades/v5/constants.go
+++ b/app/upgrades/v5/constants.go
@@ -1,9 +1,9 @@
 package v5
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	txboundary "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	txboundary "github.com/notional-labs/composable/v6/x/tx-boundary/types"
 )
 
 const (

--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -2,13 +2,13 @@ package v5
 
 import (
 	"cosmossdk.io/math"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
 )
 
 const (

--- a/app/upgrades/v5_1_0/constants.go
+++ b/app/upgrades/v5_1_0/constants.go
@@ -1,6 +1,6 @@
 package v5_1_0
 
-import "github.com/notional-labs/composable/v6/app/upgrades"
+import "github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 
 const (
 	// UpgradeName defines the on-chain upgrade name for the Composable v5 upgrade.

--- a/app/upgrades/v5_1_0/fork.go
+++ b/app/upgrades/v5_1_0/fork.go
@@ -4,9 +4,9 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/app/keepers"
-	rateLimitKeeper "github.com/notional-labs/composable/v6/x/ratelimit/keeper"
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	rateLimitKeeper "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 const uosmo = "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23"

--- a/app/upgrades/v5_2_0/constants.go
+++ b/app/upgrades/v5_2_0/constants.go
@@ -1,6 +1,6 @@
 package v5_2_0
 
-import "github.com/notional-labs/composable/v6/app/upgrades"
+import "github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 
 const (
 	// UpgradeName defines the on-chain upgrade name for the Composable v5 upgrade.

--- a/app/upgrades/v5_2_0/fork.go
+++ b/app/upgrades/v5_2_0/fork.go
@@ -2,10 +2,10 @@
 package v5_2_0
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/notional-labs/composable/v6/app/keepers"
 
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"

--- a/app/upgrades/v6/constants.go
+++ b/app/upgrades/v6/constants.go
@@ -1,9 +1,9 @@
 package v6
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v6/upgrade.go
+++ b/app/upgrades/v6/upgrade.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4/constants.go
+++ b/app/upgrades/v6_4/constants.go
@@ -3,8 +3,8 @@ package v6_4
 import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	customstmiddleware "github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	customstmiddleware "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 )
 
 const (

--- a/app/upgrades/v6_4/upgrade.go
+++ b/app/upgrades/v6_4/upgrade.go
@@ -5,10 +5,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	customstmiddleware "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	customstmiddleware "github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_4/constants.go
+++ b/app/upgrades/v6_4_4/constants.go
@@ -1,7 +1,7 @@
 package v6_4_4
 
 import (
-	"github.com/notional-labs/composable/v6/app/upgrades"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v6_4_4/upgrade.go
+++ b/app/upgrades/v6_4_4/upgrade.go
@@ -5,9 +5,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_5/constants.go
+++ b/app/upgrades/v6_4_5/constants.go
@@ -1,7 +1,7 @@
 package v6_4_5
 
 import (
-	"github.com/notional-labs/composable/v6/app/upgrades"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v6_4_5/upgrade.go
+++ b/app/upgrades/v6_4_5/upgrade.go
@@ -5,9 +5,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_6/constants.go
+++ b/app/upgrades/v6_4_6/constants.go
@@ -3,8 +3,8 @@ package v6_4_6
 import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 )
 
 const (

--- a/app/upgrades/v6_4_6/upgrade.go
+++ b/app/upgrades/v6_4_6/upgrade.go
@@ -5,10 +5,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_7/constants.go
+++ b/app/upgrades/v6_4_7/constants.go
@@ -3,7 +3,7 @@ package v6_4_7
 import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 
-	"github.com/notional-labs/composable/v6/app/upgrades"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v6_4_7/upgrade.go
+++ b/app/upgrades/v6_4_7/upgrade.go
@@ -5,9 +5,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_8/constants.go
+++ b/app/upgrades/v6_4_8/constants.go
@@ -1,9 +1,9 @@
 package v6_4_8
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 const (

--- a/app/upgrades/v6_4_8/upgrade.go
+++ b/app/upgrades/v6_4_8/upgrade.go
@@ -5,10 +5,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_9/constants.go
+++ b/app/upgrades/v6_4_9/constants.go
@@ -1,8 +1,8 @@
 package v6_4_9
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v6_4_9/upgrade.go
+++ b/app/upgrades/v6_4_9/upgrade.go
@@ -5,9 +5,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_4_91/constants.go
+++ b/app/upgrades/v6_4_91/constants.go
@@ -1,8 +1,8 @@
 package v6_4_91
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 const (

--- a/app/upgrades/v6_4_91/upgrade.go
+++ b/app/upgrades/v6_4_91/upgrade.go
@@ -5,9 +5,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v6_5_0/constants.go
+++ b/app/upgrades/v6_5_0/constants.go
@@ -1,9 +1,9 @@
 package v6_5_0
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 const (

--- a/app/upgrades/v6_5_0/upgrade.go
+++ b/app/upgrades/v6_5_0/upgrade.go
@@ -5,10 +5,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/ComposableFi/composable-cosmos/v6/app/keepers"
+	"github.com/ComposableFi/composable-cosmos/v6/app/upgrades"
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/notional-labs/composable/v6/app/keepers"
-	"github.com/notional-labs/composable/v6/app/upgrades"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 func CreateUpgradeHandler(

--- a/bech32-migration/auth/auth.go
+++ b/bech32-migration/auth/auth.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
-	"github.com/notional-labs/composable/v6/bech32-migration/utils"
+	"github.com/ComposableFi/composable-cosmos/v6/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/gov/gov.go
+++ b/bech32-migration/gov/gov.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
-	"github.com/notional-labs/composable/v6/bech32-migration/utils"
+	"github.com/ComposableFi/composable-cosmos/v6/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/slashing/slashing.go
+++ b/bech32-migration/slashing/slashing.go
@@ -6,7 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 
-	"github.com/notional-labs/composable/v6/bech32-migration/utils"
+	"github.com/ComposableFi/composable-cosmos/v6/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/staking/staking.go
+++ b/bech32-migration/staking/staking.go
@@ -6,7 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/notional-labs/composable/v6/bech32-migration/utils"
+	"github.com/ComposableFi/composable-cosmos/v6/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) {

--- a/cmd/centaurid/cmd/genaccounts.go
+++ b/cmd/centaurid/cmd/genaccounts.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/bech32-migration/utils"
+	"github.com/ComposableFi/composable-cosmos/v6/bech32-migration/utils"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/cmd/centaurid/cmd/root.go
+++ b/cmd/centaurid/cmd/root.go
@@ -33,8 +33,8 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
-	"github.com/notional-labs/composable/v6/app"
-	// "github.com/notional-labs/composable/v6/app/params"
+	"github.com/ComposableFi/composable-cosmos/v6/app"
+	// "github.com/ComposableFi/composable-cosmos/v6/app/params"
 	// this line is used by starport scaffolding # stargate/root/import
 )
 

--- a/cmd/centaurid/main.go
+++ b/cmd/centaurid/main.go
@@ -5,9 +5,9 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	"github.com/notional-labs/composable/v6/app"
-	cmd "github.com/notional-labs/composable/v6/cmd/centaurid/cmd"
-	cmdcfg "github.com/notional-labs/composable/v6/cmd/centaurid/config"
+	"github.com/ComposableFi/composable-cosmos/v6/app"
+	cmd "github.com/ComposableFi/composable-cosmos/v6/cmd/centaurid/cmd"
+	cmdcfg "github.com/ComposableFi/composable-cosmos/v6/cmd/centaurid/config"
 )
 
 func main() {

--- a/custom/bank/bank_test.go
+++ b/custom/bank/bank_test.go
@@ -9,7 +9,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/stretchr/testify/suite"
 
-	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
+	customibctesting "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting"
 )
 
 type CustomBankTestSuite struct {

--- a/custom/bank/keeper/keeper.go
+++ b/custom/bank/keeper/keeper.go
@@ -13,9 +13,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	banktypes "github.com/notional-labs/composable/v6/custom/bank/types"
+	banktypes "github.com/ComposableFi/composable-cosmos/v6/custom/bank/types"
 
-	transfermiddlewarekeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	transfermiddlewarekeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 
 	alliancekeeper "github.com/terra-money/alliance/x/alliance/keeper"
 )

--- a/custom/bank/module.go
+++ b/custom/bank/module.go
@@ -10,7 +10,7 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	custombankkeeper "github.com/notional-labs/composable/v6/custom/bank/keeper"
+	custombankkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/bank/keeper"
 )
 
 // AppModule wraps around the bank module and the bank keeper to return the right total supply ignoring bonded tokens

--- a/custom/ibc-transfer/keeper/keeper.go
+++ b/custom/ibc-transfer/keeper/keeper.go
@@ -4,12 +4,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
 
+	ibctransfermiddleware "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/keeper"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
-	ibctransfermiddleware "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/keeper"
 )
 
 type Keeper struct {

--- a/custom/ibc-transfer/keeper/msg_server.go
+++ b/custom/ibc-transfer/keeper/msg_server.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	custombankkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/bank/keeper"
+	ibctransfermiddlewaretypes "github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	custombankkeeper "github.com/notional-labs/composable/v6/custom/bank/keeper"
-	ibctransfermiddlewaretypes "github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 type msgServer struct {

--- a/custom/ibc-transfer/module.go
+++ b/custom/ibc-transfer/module.go
@@ -6,11 +6,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	custombankkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/bank/keeper"
+	customibctransferkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/ibc-transfer/keeper"
 	ibctransfermodule "github.com/cosmos/ibc-go/v7/modules/apps/transfer"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	custombankkeeper "github.com/notional-labs/composable/v6/custom/bank/keeper"
-	customibctransferkeeper "github.com/notional-labs/composable/v6/custom/ibc-transfer/keeper"
 )
 
 // AppModule wraps around the bank module and the bank keeper to return the right total supply

--- a/custom/staking/abci.go
+++ b/custom/staking/abci.go
@@ -11,7 +11,7 @@ import (
 	// "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	customstakingkeeper "github.com/notional-labs/composable/v6/custom/staking/keeper"
+	customstakingkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/staking/keeper"
 )
 
 // Called every block, update validator set

--- a/custom/staking/keeper/keeper.go
+++ b/custom/staking/keeper/keeper.go
@@ -7,14 +7,14 @@ import (
 	abcicometbft "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 
+	mintkeeper "github.com/ComposableFi/composable-cosmos/v6/x/mint/keeper"
+	minttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
+	stakingmiddleware "github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/keeper"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
-	mintkeeper "github.com/notional-labs/composable/v6/x/mint/keeper"
-	minttypes "github.com/notional-labs/composable/v6/x/mint/types"
-	stakingmiddleware "github.com/notional-labs/composable/v6/x/stakingmiddleware/keeper"
 )
 
 type Keeper struct {

--- a/custom/staking/module.go
+++ b/custom/staking/module.go
@@ -11,9 +11,9 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	// custombankkeeper "github.com/notional-labs/composable/v6/custom/bank/keeper"
+	// custombankkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/bank/keeper"
+	customstakingkeeper "github.com/ComposableFi/composable-cosmos/v6/custom/staking/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	customstakingkeeper "github.com/notional-labs/composable/v6/custom/staking/keeper"
 )
 
 // AppModule wraps around the bank module and the bank keeper to return the right total supply

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/notional-labs/composable/v6
+module github.com/ComposableFi/composable-cosmos/v6
 
 go 1.20
 

--- a/x/ibc-hooks/client/cli/query.go
+++ b/x/ibc-hooks/client/cli/query.go
@@ -9,9 +9,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/keeper"
 
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
 )
 
 func indexRunCmd(cmd *cobra.Command, _ []string) error {

--- a/x/ibc-hooks/keeper/keeper.go
+++ b/x/ibc-hooks/keeper/keeper.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
 )
 
 type (

--- a/x/ibc-hooks/module.go
+++ b/x/ibc-hooks/module.go
@@ -10,8 +10,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/client/cli"
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
 
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 

--- a/x/ibc-hooks/relay_test.go
+++ b/x/ibc-hooks/relay_test.go
@@ -10,8 +10,8 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/stretchr/testify/suite"
 
-	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
-	ibchookskeeper "github.com/notional-labs/composable/v6/x/ibc-hooks/keeper"
+	customibctesting "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting"
+	ibchookskeeper "github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/keeper"
 )
 
 // TODO: use testsuite here.

--- a/x/ibc-hooks/wasm_hook.go
+++ b/x/ibc-hooks/wasm_hook.go
@@ -11,8 +11,8 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/keeper"
-	"github.com/notional-labs/composable/v6/x/ibc-hooks/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibc-hooks/types"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/ibctransfermiddleware/client/cli/query.go
+++ b/x/ibctransfermiddleware/client/cli/query.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 // GetQueryCmd returns the cli query commands for the staking middleware module.

--- a/x/ibctransfermiddleware/client/cli/tx.go
+++ b/x/ibctransfermiddleware/client/cli/tx.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/version"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 	"github.com/spf13/cobra"
 )
 

--- a/x/ibctransfermiddleware/keeper/genesis.go
+++ b/x/ibctransfermiddleware/keeper/genesis.go
@@ -1,8 +1,8 @@
 package keeper
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 // InitGenesis new stake middleware genesis

--- a/x/ibctransfermiddleware/keeper/grpc_query.go
+++ b/x/ibctransfermiddleware/keeper/grpc_query.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/ibctransfermiddleware/keeper/keeper.go
+++ b/x/ibctransfermiddleware/keeper/keeper.go
@@ -1,8 +1,8 @@
 package keeper
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"

--- a/x/ibctransfermiddleware/keeper/msg_server.go
+++ b/x/ibctransfermiddleware/keeper/msg_server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/ibctransfermiddleware/module.go
+++ b/x/ibctransfermiddleware/module.go
@@ -16,9 +16,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/client/cli"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/keeper"
-	"github.com/notional-labs/composable/v6/x/ibctransfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ibctransfermiddleware/types"
 )
 
 var (

--- a/x/mint/abci.go
+++ b/x/mint/abci.go
@@ -6,8 +6,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/mint/keeper"
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // BeginBlocker mints new tokens for the previous block.

--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // GetQueryCmd returns the cli query commands for the minting module.

--- a/x/mint/client/cli/tx.go
+++ b/x/mint/client/cli/tx.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // GetTxCmd returns the tx commands for mint

--- a/x/mint/keeper/genesis.go
+++ b/x/mint/keeper/genesis.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // InitGenesis new mint genesis

--- a/x/mint/keeper/grpc_query.go
+++ b/x/mint/keeper/grpc_query.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -10,7 +10,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // Keeper of the mint store

--- a/x/mint/keeper/msg_server.go
+++ b/x/mint/keeper/msg_server.go
@@ -8,7 +8,7 @@ import (
 
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -16,10 +16,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/notional-labs/composable/v6/x/mint/client/cli"
-	"github.com/notional-labs/composable/v6/x/mint/keeper"
-	"github.com/notional-labs/composable/v6/x/mint/simulation"
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/simulation"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 var (

--- a/x/mint/simulation/decoder.go
+++ b/x/mint/simulation/decoder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // NewDecodeStore returns a decoder function closure that unmarshals the KVPair's

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 
-	"github.com/notional-labs/composable/v6/x/mint/simulation"
-	composableminttypes "github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/simulation"
+	composableminttypes "github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 func TestDecodeStore(t *testing.T) {

--- a/x/mint/simulation/genesis.go
+++ b/x/mint/simulation/genesis.go
@@ -9,7 +9,7 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // Simulation parameter constants

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -14,8 +14,8 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/mint"
 
-	"github.com/notional-labs/composable/v6/x/mint/simulation"
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/simulation"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // TestRandomizedGenState tests the normal scenario of applying RandomizedGenState.

--- a/x/mint/simulation/proposals.go
+++ b/x/mint/simulation/proposals.go
@@ -8,7 +8,7 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 // Simulation operation weights constants

--- a/x/mint/simulation/proposals_test.go
+++ b/x/mint/simulation/proposals_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/address"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/notional-labs/composable/v6/x/mint/simulation"
-	"github.com/notional-labs/composable/v6/x/mint/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/simulation"
+	"github.com/ComposableFi/composable-cosmos/v6/x/mint/types"
 )
 
 func TestProposalMsgs(t *testing.T) {

--- a/x/ratelimit/client/cli/query.go
+++ b/x/ratelimit/client/cli/query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module.

--- a/x/ratelimit/client/cli/tx.go
+++ b/x/ratelimit/client/cli/tx.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 // GetTxCmd returns the tx commands for router

--- a/x/ratelimit/ibc_middleware.go
+++ b/x/ratelimit/ibc_middleware.go
@@ -3,7 +3,7 @@ package ratelimit
 import (
 	"fmt"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 

--- a/x/ratelimit/keeper/abci.go
+++ b/x/ratelimit/keeper/abci.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 // BeginBlocker of epochs module.

--- a/x/ratelimit/keeper/epoch.go
+++ b/x/ratelimit/keeper/epoch.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/x/ratelimit/keeper/genesis.go
+++ b/x/ratelimit/keeper/genesis.go
@@ -6,7 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {

--- a/x/ratelimit/keeper/grpc_query.go
+++ b/x/ratelimit/keeper/grpc_query.go
@@ -8,7 +8,7 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/ratelimit/keeper/keeper.go
+++ b/x/ratelimit/keeper/keeper.go
@@ -10,8 +10,8 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
-	tfmwkeeper "github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
+	tfmwkeeper "github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 )
 
 type Keeper struct {

--- a/x/ratelimit/keeper/msg_server.go
+++ b/x/ratelimit/keeper/msg_server.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/ratelimit/keeper/packet.go
+++ b/x/ratelimit/keeper/packet.go
@@ -14,7 +14,7 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 type RateLimitedPacketInfo struct {

--- a/x/ratelimit/keeper/rate_limit.go
+++ b/x/ratelimit/keeper/rate_limit.go
@@ -11,7 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 // Get the rate limit byte key built from the denom and channelID

--- a/x/ratelimit/module.go
+++ b/x/ratelimit/module.go
@@ -16,9 +16,9 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/ratelimit/client/cli"
-	"github.com/notional-labs/composable/v6/x/ratelimit/keeper"
-	"github.com/notional-labs/composable/v6/x/ratelimit/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 var (

--- a/x/ratelimit/relay_test.go
+++ b/x/ratelimit/relay_test.go
@@ -8,8 +8,8 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/stretchr/testify/suite"
 
-	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
-	ratelimittypes "github.com/notional-labs/composable/v6/x/ratelimit/types"
+	customibctesting "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting"
+	ratelimittypes "github.com/ComposableFi/composable-cosmos/v6/x/ratelimit/types"
 )
 
 type RateLimitTestSuite struct {

--- a/x/stakingmiddleware/client/cli/query.go
+++ b/x/stakingmiddleware/client/cli/query.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
 )
 
 // GetQueryCmd returns the cli query commands for the staking middleware module.

--- a/x/stakingmiddleware/client/cli/tx.go
+++ b/x/stakingmiddleware/client/cli/tx.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
 	"github.com/spf13/cobra"
 )
 

--- a/x/stakingmiddleware/keeper/genesis.go
+++ b/x/stakingmiddleware/keeper/genesis.go
@@ -1,8 +1,8 @@
 package keeper
 
 import (
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
 )
 
 // InitGenesis new stake middleware genesis

--- a/x/stakingmiddleware/keeper/grpc_query.go
+++ b/x/stakingmiddleware/keeper/grpc_query.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/stakingmiddleware/keeper/keeper.go
+++ b/x/stakingmiddleware/keeper/keeper.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"fmt"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"

--- a/x/stakingmiddleware/keeper/msg_server.go
+++ b/x/stakingmiddleware/keeper/msg_server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/stakingmiddleware/module.go
+++ b/x/stakingmiddleware/module.go
@@ -16,9 +16,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/client/cli"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/keeper"
-	"github.com/notional-labs/composable/v6/x/stakingmiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/stakingmiddleware/types"
 )
 
 var (

--- a/x/transfermiddleware/client/cli/query.go
+++ b/x/transfermiddleware/client/cli/query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 // GetQueryCmd returns the query commands for router

--- a/x/transfermiddleware/client/cli/tx.go
+++ b/x/transfermiddleware/client/cli/tx.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 // GetTxCmd returns the tx commands for router

--- a/x/transfermiddleware/ibc_ante_test.go
+++ b/x/transfermiddleware/ibc_ante_test.go
@@ -12,7 +12,7 @@ import (
 	wasmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/08-wasm/types"
 	"github.com/stretchr/testify/suite"
 
-	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
+	customibctesting "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting"
 )
 
 // NOTE: This is the address of the gov authority on the chain that is being tested.

--- a/x/transfermiddleware/ibc_middleware.go
+++ b/x/transfermiddleware/ibc_middleware.go
@@ -11,7 +11,7 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
 )
 
 var _ porttypes.Middleware = &IBCMiddleware{}

--- a/x/transfermiddleware/keeper/abci.go
+++ b/x/transfermiddleware/keeper/abci.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 // BeginBlocker of epochs module.

--- a/x/transfermiddleware/keeper/genesis.go
+++ b/x/transfermiddleware/keeper/genesis.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 // TODO: add init genesis logic

--- a/x/transfermiddleware/keeper/genesis_test.go
+++ b/x/transfermiddleware/keeper/genesis_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	helpers "github.com/notional-labs/composable/v6/app/helpers"
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	helpers "github.com/ComposableFi/composable-cosmos/v6/app/helpers"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 func TestTFMInitGenesis(t *testing.T) {

--- a/x/transfermiddleware/keeper/grpc_query.go
+++ b/x/transfermiddleware/keeper/grpc_query.go
@@ -3,11 +3,11 @@ package keeper
 import (
 	"context"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
 )
 
 func (k Keeper) ParaTokenInfo(c context.Context, req *types.QueryParaTokenInfoRequest) (*types.QueryParaTokenInfoResponse, error) {

--- a/x/transfermiddleware/keeper/ics4wrapper.go
+++ b/x/transfermiddleware/keeper/ics4wrapper.go
@@ -12,7 +12,7 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 func (keeper Keeper) hasParachainIBCTokenInfo(ctx sdk.Context, nativeDenom string) bool {

--- a/x/transfermiddleware/keeper/keeper.go
+++ b/x/transfermiddleware/keeper/keeper.go
@@ -15,7 +15,7 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 type Keeper struct {

--- a/x/transfermiddleware/keeper/msg_server.go
+++ b/x/transfermiddleware/keeper/msg_server.go
@@ -9,7 +9,7 @@ import (
 	"cosmossdk.io/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/transfermiddleware/keeper/params.go
+++ b/x/transfermiddleware/keeper/params.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {

--- a/x/transfermiddleware/keeper/relay.go
+++ b/x/transfermiddleware/keeper/relay.go
@@ -6,7 +6,7 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 func (k Keeper) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, data transfertypes.FungibleTokenPacketData) error {

--- a/x/transfermiddleware/module.go
+++ b/x/transfermiddleware/module.go
@@ -16,9 +16,9 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/client/cli"
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/keeper"
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 var (

--- a/x/transfermiddleware/pfm_test.go
+++ b/x/transfermiddleware/pfm_test.go
@@ -13,7 +13,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/stretchr/testify/suite"
 
-	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
+	customibctesting "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting"
 )
 
 type PacketMetadata struct {

--- a/x/transfermiddleware/relay_test.go
+++ b/x/transfermiddleware/relay_test.go
@@ -10,7 +10,7 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	"github.com/stretchr/testify/suite"
 
-	customibctesting "github.com/notional-labs/composable/v6/app/ibctesting"
+	customibctesting "github.com/ComposableFi/composable-cosmos/v6/app/ibctesting"
 )
 
 // TODO: use testsuite here.

--- a/x/transfermiddleware/types/info_test.go
+++ b/x/transfermiddleware/types/info_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/notional-labs/composable/v6/x/transfermiddleware/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/transfermiddleware/types"
 )
 
 func TestValidateBasic(t *testing.T) {

--- a/x/tx-boundary/ante/antetest/ante_test.go
+++ b/x/tx-boundary/ante/antetest/ante_test.go
@@ -3,14 +3,14 @@ package antetest
 import (
 	"testing"
 
+	txboundaryAnte "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/ante"
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	txboundaryAnte "github.com/notional-labs/composable/v6/x/tx-boundary/ante"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )

--- a/x/tx-boundary/ante/antetest/ante_test_setup.go
+++ b/x/tx-boundary/ante/antetest/ante_test_setup.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/ComposableFi/composable-cosmos/v6/app"
+	"github.com/ComposableFi/composable-cosmos/v6/app/helpers"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -17,8 +19,6 @@ import (
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/ibc-go/v7/testing/mock"
-	"github.com/notional-labs/composable/v6/app"
-	"github.com/notional-labs/composable/v6/app/helpers"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )

--- a/x/tx-boundary/ante/decorate.go
+++ b/x/tx-boundary/ante/decorate.go
@@ -7,9 +7,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	txBoundaryKeeper "github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/keeper"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	txBoundaryKeeper "github.com/notional-labs/composable/v6/x/tx-boundary/keeper"
 )
 
 type StakingPermissionDecorator struct {

--- a/x/tx-boundary/client/cli/query.go
+++ b/x/tx-boundary/client/cli/query.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
 )
 
 // GetQueryCmd returns the cli query commands for the tx-boundary module.

--- a/x/tx-boundary/client/cli/tx.go
+++ b/x/tx-boundary/client/cli/tx.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"strconv"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
 	"github.com/spf13/cobra"
 )
 

--- a/x/tx-boundary/keeper/genensis.go
+++ b/x/tx-boundary/keeper/genensis.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 )
 
 // InitGenesis initializes the capability module's state from a provided genesis

--- a/x/tx-boundary/keeper/grpc_query.go
+++ b/x/tx-boundary/keeper/grpc_query.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"context"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/tx-boundary/keeper/keeper.go
+++ b/x/tx-boundary/keeper/keeper.go
@@ -9,7 +9,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 )
 
 // Keeper struct

--- a/x/tx-boundary/keeper/keeper_test.go
+++ b/x/tx-boundary/keeper/keeper_test.go
@@ -8,9 +8,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/notional-labs/composable/v6/app"
-	"github.com/notional-labs/composable/v6/app/helpers"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
+	"github.com/ComposableFi/composable-cosmos/v6/app"
+	"github.com/ComposableFi/composable-cosmos/v6/app/helpers"
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 )
 
 type KeeperTestSuite struct {

--- a/x/tx-boundary/module.go
+++ b/x/tx-boundary/module.go
@@ -9,15 +9,15 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/client/cli"
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/keeper"
+	"github.com/ComposableFi/composable-cosmos/v6/x/tx-boundary/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/client/cli"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/keeper"
-	"github.com/notional-labs/composable/v6/x/tx-boundary/types"
 )
 
 var (


### PR DESCRIPTION
We have been depending on a very old edition of x/transfermiddleware in packet forward middleware.  

In order to resolve this, we need to rename the module from github.com/notional-labs/composable/v6 to github.com/ComposableFi/composable-cosmos/v6 and then reference a v6.6.0, but for now we can just use this commit.  

Then, we need to update packet forward middleware to refer to this commit, and push that to our fork.

This also involves refactoring simapp in packetforwardmiddleware.

From there, we make another update to this branch to refer to that, and we can continue to debug knowing that we're for sure using the correct code.

The ongoing simapp refactor is here:

https://github.com/faddat/ibc-apps/tree/faddat/composable-ibc-apps

We won't want to merge this PR until the changes to ibc-apps are completed.

