### PR TITLE
Specify a correct denom instead of empty/ibc transfer

### DIFF
--- a/custom/ibc-transfer/keeper/keeper.go
+++ b/custom/ibc-transfer/keeper/keeper.go
@@ -58,9 +58,8 @@ func NewKeeper(
 // If the transfer amount is greater than the minimum fee, it will charge the minimum fee and the percentage fee.
 func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.MsgTransferResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	charge_coin := msg.Token
-	extra_charge := false
 	params := k.IbcTransfermiddleware.GetParams(ctx)
+	charge_coin := sdk.NewCoin("", sdk.ZeroInt())
 	if params.ChannelFees != nil && len(params.ChannelFees) > 0 {
 		channelFee := findChannelParams(params.ChannelFees, msg.SourceChannel)
 		if channelFee != nil {
@@ -126,18 +125,16 @@ func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.
 				return &types.MsgTransferResponse{}, nil
 			}
 			msg.Token.Amount = newAmount
-			extra_charge = true
 		}
 	}
 	ret, err := k.Keeper.Transfer(goCtx, msg)
-	if err == nil && ret != nil && extra_charge {
+	if err == nil && ret != nil && !charge_coin.IsZero() {
 		k.IbcTransfermiddleware.SetSequenceFee(ctx, ret.Sequence, charge_coin)
 	}
 	return ret, err
 }
 
 func GetPriority(jsonString string) *string {
-	return nil
 	var data map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonString), &data); err != nil {
 		return nil

--- a/custom/ibc-transfer/keeper/keeper.go
+++ b/custom/ibc-transfer/keeper/keeper.go
@@ -59,7 +59,7 @@ func NewKeeper(
 func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.MsgTransferResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	params := k.IbcTransfermiddleware.GetParams(ctx)
-	charge_coin := sdk.NewCoin("", sdk.ZeroInt())
+	charge_coin := sdk.NewCoin(msg.Token.Denom, sdk.ZeroInt())
 	if params.ChannelFees != nil && len(params.ChannelFees) > 0 {
 		channelFee := findChannelParams(params.ChannelFees, msg.SourceChannel)
 		if channelFee != nil {

--- a/custom/ibc-transfer/keeper/msg_server.go
+++ b/custom/ibc-transfer/keeper/msg_server.go
@@ -33,7 +33,7 @@ func NewMsgServerImpl(ibcKeeper Keeper, bankKeeper custombankkeeper.Keeper) type
 func (k msgServer) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.MsgTransferResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	params := k.Keeper.IbcTransfermiddleware.GetParams(ctx)
-	charge_coin := sdk.NewCoin("", sdk.ZeroInt())
+	charge_coin := sdk.NewCoin(msg.Token.Denom, sdk.ZeroInt())
 	if params.ChannelFees != nil && len(params.ChannelFees) > 0 {
 		channelFee := findChannelParams(params.ChannelFees, msg.SourceChannel)
 		if channelFee != nil {

--- a/custom/ibc-transfer/keeper/msg_server.go
+++ b/custom/ibc-transfer/keeper/msg_server.go
@@ -31,9 +31,11 @@ func NewMsgServerImpl(ibcKeeper Keeper, bankKeeper custombankkeeper.Keeper) type
 // If the transfer amount is less than the minimum fee, it will charge the full transfer amount.
 // If the transfer amount is greater than the minimum fee, it will charge the minimum fee and the percentage fee.
 func (k msgServer) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.MsgTransferResponse, error) {
+	// return k.msgServer.Transfer(goCtx, msg)
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	charge_coin := msg.Token
+	extra_charge := false
 	params := k.Keeper.IbcTransfermiddleware.GetParams(ctx)
-	charge_coin := sdk.NewCoin("", sdk.ZeroInt())
 	if params.ChannelFees != nil && len(params.ChannelFees) > 0 {
 		channelFee := findChannelParams(params.ChannelFees, msg.SourceChannel)
 		if channelFee != nil {
@@ -99,10 +101,11 @@ func (k msgServer) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*typ
 				return &types.MsgTransferResponse{}, nil
 			}
 			msg.Token.Amount = newAmount
+			extra_charge = true
 		}
 	}
 	ret, err := k.msgServer.Transfer(goCtx, msg)
-	if err == nil && ret != nil && !charge_coin.IsZero() {
+	if err == nil && ret != nil && extra_charge {
 		k.IbcTransfermiddleware.SetSequenceFee(ctx, ret.Sequence, charge_coin)
 	}
 	return ret, err


### PR DESCRIPTION
empty demon triggers an issue "incorrect denom"
